### PR TITLE
Remove lazy_static + cleanup lib.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ required-features = ["build-binary"]
 
 [dependencies]
 glob = "0.3"
-lazy_static = "1.4"
 docopt = { version = "1.1", optional = true }
 
 [features]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use std::{fmt, result, string};
 use std::error::Error;
+use std::{fmt, result};
 
 use glob;
 
@@ -20,14 +20,12 @@ pub type Result<T> = result::Result<T, JavaLocatorError>;
 
 #[derive(Debug)]
 pub struct JavaLocatorError {
-    description: String
+    description: String,
 }
 
 impl JavaLocatorError {
-    pub(crate) fn new(description: &str) -> JavaLocatorError {
-        JavaLocatorError {
-            description: description.to_string(),
-        }
+    pub(crate) fn new(description: String) -> JavaLocatorError {
+        JavaLocatorError { description }
     }
 }
 
@@ -45,18 +43,24 @@ impl Error for JavaLocatorError {
 
 impl From<std::io::Error> for JavaLocatorError {
     fn from(err: std::io::Error) -> JavaLocatorError {
-        JavaLocatorError { description: format!("{:?}", err) }
+        JavaLocatorError {
+            description: format!("{:?}", err),
+        }
     }
 }
 
-impl From<string::FromUtf8Error> for JavaLocatorError {
-    fn from(err: string::FromUtf8Error) -> JavaLocatorError {
-        JavaLocatorError { description: format!("{:?}", err) }
+impl From<std::str::Utf8Error> for JavaLocatorError {
+    fn from(err: std::str::Utf8Error) -> JavaLocatorError {
+        JavaLocatorError {
+            description: format!("{:?}", err),
+        }
     }
 }
 
 impl From<glob::PatternError> for JavaLocatorError {
     fn from(err: glob::PatternError) -> JavaLocatorError {
-        JavaLocatorError { description: format!("{:?}", err) }
+        JavaLocatorError {
+            description: format!("{:?}", err),
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 use docopt::Docopt;
 
-use java_locator;
-
-const USAGE: &'static str = "
+const USAGE: &str = "
 java-locator locates the active Java installation in the host.
 
 Usage:


### PR DESCRIPTION
This PR performs general cleanup on lib.rs:
* lazy_static is removed as a dependency
   + Instead we can just directly use `#[cfg(target_os = "..")]` as needed.
* A unique implementation of do_locate_java_home is provided for windows, macos and unix.
  + This approach makes it very easy to understand the implementation for a single system, since they deviate so much it doesnt really make sense to try following the flow of multiple systems.
* Removed a bunch of allocations by avoiding clones and `&str` -> `String` conversions
* Fixes a bug on windows where the last path output by `where` was chosen.
   + The correct behavior is to choose the first path as that is the path that java will be run from.
   + I removed the warning here since its reasonable for the user to have multiple java's in their path, no point in warning about it, just pick the correct one.
  
As a result of the cleanup:
* The code should be very slightly faster, its certainly not a hotpath but applications starting up slightly faster is always nice.
* Improve compile times
  + one less dependency to build
* The compiled binaries for `java-locator` are smaller.
  + -134KB for debug
  + -10KB for release
* The implementation is more readable.
* There is less total lines of code

## future cleanup

I've left some changes out of this PR since they are breaking changes to the API so we should consider them separately.

* Return PathBuf instead of String
   + since we are returning a path it should really be a PathBuf instead of a String.
* replace glob with manual recursive search implementation
   + I was hoping to remove the usage of glob in this PR since we are spending ~200ms in the call to glob on my machine.
   + we expose globing to the user as part of the java-locator API, so removing glob would be a breaking change.

